### PR TITLE
bump binary-search-bounds v2 in filtered-vector

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "binary-search-bounds": "^1.0.0",
+    "binary-search-bounds": "^2.0.0",
     "cubic-hermite": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
cc: plotly/plotly.js#897